### PR TITLE
Bcftools filtering dp5 q20

### DIFF
--- a/modules/bcftools.nf
+++ b/modules/bcftools.nf
@@ -15,16 +15,14 @@ process BCFTOOLS_MPILEUP {
     tuple val(reference), path("${params.project}_${reference}.filtered.vcf"), emit: filtered_vcf, optional: true
     
     script:
-    def filter_cmd = (reference == "transition" || reference == "full") ? 
+    def filter_cmd = (reference == "transition" || reference == "full") ?
         """
-        bcftools view -i 'QUAL>=20 && FORMAT/DP>=5' --exclude-types indels \
-            ${params.project}_${reference}.vcf \
-            -O v \
+        bcftools view --exclude-types indels ${params.project}_${reference}.vcf \
+        | bcftools +setGT - -- -t q -i 'DP<5 || QUAL<20' -n . \
+            -O v \\
             -o ${params.project}_${reference}.filtered.vcf
-        """ : 
+        """ :
         ""
-
-    """
     bcftools mpileup -a AD,DP,INFO/AD \
         -B -q 20 -Q 20 \
         -f ${ref} \

--- a/modules/bcftools.nf
+++ b/modules/bcftools.nf
@@ -18,7 +18,7 @@ process BCFTOOLS_MPILEUP {
     def filter_cmd = (reference == "transition" || reference == "full") ?
         """
         bcftools view --exclude-types indels ${params.project}_${reference}.vcf \
-        | bcftools +setGT - -- -t q -i 'FMT/DP<5 || QUAL<20' -n . \
+        | bcftools +setGT - -- -t q -i 'FORMAT/DP<5 || QUAL<20' -n . \
         > ${params.project}_${reference}.filtered.vcf
         """ :
         ""

--- a/modules/bcftools.nf
+++ b/modules/bcftools.nf
@@ -18,8 +18,9 @@ process BCFTOOLS_MPILEUP {
     def filter_cmd = (reference == "transition" || reference == "full") ?
         """
         bcftools view --exclude-types indels ${params.project}_${reference}.vcf \
-        | bcftools +setGT - -- -t q -i 'FORMAT/DP<20 || QUAL<20' -n . \
-        > ${params.project}_${reference}.filtered.vcf
+        | bcftools filter -S . -e 'FORMAT/DP<5 || QUAL<20' \
+        -O v \
+        -o ${params.project}_${reference}.filtered.vcf
         """ :
         ""
 

--- a/modules/bcftools.nf
+++ b/modules/bcftools.nf
@@ -18,7 +18,7 @@ process BCFTOOLS_MPILEUP {
     def filter_cmd = (reference == "transition" || reference == "full") ?
         """
         bcftools view --exclude-types indels ${params.project}_${reference}.vcf \
-        | bcftools +setGT - -- -t q -i 'FORMAT/DP<5 || QUAL<20' -n . \
+        | bcftools +setGT - -- -t q -i 'FORMAT/DP<10 || QUAL<20' -n . \
         > ${params.project}_${reference}.filtered.vcf
         """ :
         ""

--- a/modules/bcftools.nf
+++ b/modules/bcftools.nf
@@ -19,7 +19,7 @@ process BCFTOOLS_MPILEUP {
         """
         bcftools view --exclude-types indels ${params.project}_${reference}.vcf \
         | bcftools +setGT - -- -t q -i 'DP<5 || QUAL<20' -n . \
-            -O v \\
+            -O v \
             -o ${params.project}_${reference}.filtered.vcf
         """ :
         ""

--- a/modules/bcftools.nf
+++ b/modules/bcftools.nf
@@ -18,9 +18,8 @@ process BCFTOOLS_MPILEUP {
     def filter_cmd = (reference == "transition" || reference == "full") ?
         """
         bcftools view --exclude-types indels ${params.project}_${reference}.vcf \
-        | bcftools filter -S . -e 'FORMAT/DP<5 || QUAL<20' \
-        -O v \
-        -o ${params.project}_${reference}.filtered.vcf
+        | bcftools +setGT - -- -t q -i 'FORMAT/DP<5 || QUAL<20' -n . \
+        > ${params.project}_${reference}.filtered.vcf
         """ :
         ""
 

--- a/modules/bcftools.nf
+++ b/modules/bcftools.nf
@@ -18,7 +18,7 @@ process BCFTOOLS_MPILEUP {
     def filter_cmd = (reference == "transition" || reference == "full") ?
         """
         bcftools view --exclude-types indels ${params.project}_${reference}.vcf \
-        | bcftools +setGT - -- -t q -i 'FORMAT/DP<10 || QUAL<20' -n . \
+        | bcftools +setGT - -- -t q -i 'FORMAT/DP<20 || QUAL<20' -n . \
         > ${params.project}_${reference}.filtered.vcf
         """ :
         ""

--- a/modules/bcftools.nf
+++ b/modules/bcftools.nf
@@ -18,7 +18,7 @@ process BCFTOOLS_MPILEUP {
     def filter_cmd = (reference == "transition" || reference == "full") ?
         """
         bcftools view --exclude-types indels ${params.project}_${reference}.vcf \
-        | bcftools +setGT - -- -t q -i 'FORMAT/DP<5 || QUAL<20' -n . \
+        | bcftools +setGT - -- -i 'FORMAT/DP<5 || QUAL<20' -n . \
         > ${params.project}_${reference}.filtered.vcf
         """ :
         ""

--- a/modules/bcftools.nf
+++ b/modules/bcftools.nf
@@ -23,6 +23,8 @@ process BCFTOOLS_MPILEUP {
             -o ${params.project}_${reference}.filtered.vcf
         """ :
         ""
+
+    """
     bcftools mpileup -a AD,DP,INFO/AD \
         -B -q 20 -Q 20 \
         -f ${ref} \

--- a/modules/bcftools.nf
+++ b/modules/bcftools.nf
@@ -18,7 +18,7 @@ process BCFTOOLS_MPILEUP {
     def filter_cmd = (reference == "transition" || reference == "full") ?
         """
         bcftools view --exclude-types indels ${params.project}_${reference}.vcf \
-        | bcftools +setGT - -- -t q -i 'DP<5 || QUAL<20' -n . \
+        | bcftools +setGT - -- -t q -i 'FMT/DP<5 || QUAL<20' -n . \
         > ${params.project}_${reference}.filtered.vcf
         """ :
         ""

--- a/modules/bcftools.nf
+++ b/modules/bcftools.nf
@@ -19,8 +19,7 @@ process BCFTOOLS_MPILEUP {
         """
         bcftools view --exclude-types indels ${params.project}_${reference}.vcf \
         | bcftools +setGT - -- -t q -i 'DP<5 || QUAL<20' -n . \
-            -O v \
-            -o ${params.project}_${reference}.filtered.vcf
+        > ${params.project}_${reference}.filtered.vcf
         """ :
         ""
 

--- a/modules/bcftools.nf
+++ b/modules/bcftools.nf
@@ -18,7 +18,7 @@ process BCFTOOLS_MPILEUP {
     def filter_cmd = (reference == "transition" || reference == "full") ?
         """
         bcftools view --exclude-types indels ${params.project}_${reference}.vcf \
-        | bcftools +setGT - -- -i 'FORMAT/DP<5 || QUAL<20' -n . \
+        | bcftools +setGT - -- -t q -i 'FORMAT/DP<5 || QUAL<20' -n . \
         > ${params.project}_${reference}.filtered.vcf
         """ :
         ""


### PR DESCRIPTION
This modified script uses an updated bcftools command that properly filters individual by individual and site by site, replacing genotypes with depth < 5 and qual < 20 with null values (./.) in the resulting VCF.