### PR TITLE
Bcftools filtering dp5 q20 (#16)

### DIFF
--- a/modules/bcftools.nf
+++ b/modules/bcftools.nf
@@ -15,13 +15,12 @@ process BCFTOOLS_MPILEUP {
     tuple val(reference), path("${params.project}_${reference}.filtered.vcf"), emit: filtered_vcf, optional: true
     
     script:
-    def filter_cmd = (reference == "transition" || reference == "full") ? 
+    def filter_cmd = (reference == "transition" || reference == "full") ?
         """
-        bcftools view -i 'QUAL>=20 && FORMAT/DP>=5' --exclude-types indels \
-            ${params.project}_${reference}.vcf \
-            -O v \
-            -o ${params.project}_${reference}.filtered.vcf
-        """ : 
+        bcftools view --exclude-types indels ${params.project}_${reference}.vcf \
+        | bcftools +setGT - -- -t q -i 'FORMAT/DP<5 || QUAL<20' -n . \
+        > ${params.project}_${reference}.filtered.vcf
+        """ :
         ""
 
     """


### PR DESCRIPTION
* Update bcftools.nf

Updated filter_cmd to remove sites on an individual-by-individual basis if read depth or qual are less than threshold (previous iteration kept site if at least one individual passed filter for that site).