### PR TITLE
change Feather River Spring reporting name to Feather River-lineage Sp

### DIFF
--- a/bin/rubias.R
+++ b/bin/rubias.R
@@ -405,7 +405,7 @@ raw_repunit_probs <- all_full_mix_results %>%
   left_join(ots28_info, by = "indiv") %>%
   mutate(
     tributary = case_when(
-      (RoSA == "Early") & (repunit %in% c("fall", "latefall")) & (Prob_repunit >= PofZ_threshold) & ((n_miss_loci / (n_miss_loci + n_non_miss_loci)) < gsi_missing_threshold) ~ "Feather River Spring",
+      (RoSA == "Early") & (repunit %in% c("fall", "latefall")) & (Prob_repunit >= PofZ_threshold) & ((n_miss_loci / (n_miss_loci + n_non_miss_loci)) < gsi_missing_threshold) ~ "Feather River-lineage Spring",
       (RoSA == "Late") & (repunit == "spring") & (Prob_repunit > PofZ_threshold) ~ NA_character_,
       repunit == "spring" ~ collection,
       TRUE ~ NA_character_


### PR DESCRIPTION
Changed rubias output to call "Feather River-lineage Spring" instead of "Feather River Spring" when GB fall with early RoSA