### PR TITLE
Add chunking to bcftools, fixed Nextflow buffer, tbl_df workaround

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,11 @@ output/*
 test/*
 data/genome_cache/*
 .gitignore
+*.sam
+*.smk
+*.html
+*.zip
+*.fastq
+*.fastq.gz
+test_run*
+*.pdf

--- a/bin/gen_haps.R
+++ b/bin/gen_haps.R
@@ -17,6 +17,14 @@ find_missing_samples2 <- function (raw_data, filtered_data)
   missing_samples
 }
 
+clean_sample_name <- function(x) {
+  x %>%
+    str_remove("_$") %>% # Remove trailing underscore
+    str_remove("_S\\d+_?$") %>% # Remove _S123_ suffix
+    str_remove("_R\\d+_?$") %>% # Remove _R123_ suffix
+    str_remove("_L\\d+_?$") # Remove _L123_ suffix
+}
+
 # 1. Find the correct .rds files
 dirFiles <- list.files()
 rds.file <- grep(".rds", dirFiles)
@@ -34,7 +42,7 @@ hap <- map_dfr(dirFiles[rds.files.to.read], function(f) {
   ) %>% 
   dplyr::filter(haplo != "haplo") %>%
   mutate(
-    indiv.ID = str_remove(indiv.ID,"_*$") # Remove any trailing underscores from individual IDs
+    indiv.ID = clean_sample_name(indiv.ID)
   )
 
 unfiltered_output_filename <- paste0(project_name, "_observed_unfiltered_haplotype.csv")

--- a/bin/prep_mhp_rds.R
+++ b/bin/prep_mhp_rds.R
@@ -8,6 +8,12 @@ reference_name <- args[5]
 
 
 # Setup ---------------
+# Workaround for deprecated/defunct tbl_df in newer dplyr versions
+library(dplyr)
+ns <- asNamespace("dplyr")
+unlockBinding("tbl_df", ns)
+assign("tbl_df", tibble::as_tibble, envir = ns)
+lockBinding("tbl_df", ns)
 library(microhaplot)
 
 haplo.read.tbl <- prepHaplotFiles(

--- a/bin/rubias.R
+++ b/bin/rubias.R
@@ -243,6 +243,13 @@ ots28_info <- read_tsv(ots28_info_file) %>%
 unk_match <- unks %>%
   select(any_of(names(ref_baseline))) # Keep only columns (loci) that are in ref_baseline
 
+if (!"collection" %in% colnames(unk_match)) {
+  stop("ERROR: The 'collection' column is missing from the baseline or mixtures. Please check that the correct GSI baseline file (e.g. SWFSC reference baseline) was provided.")
+}
+if (!"indiv" %in% colnames(unk_match)) {
+  stop("ERROR: The 'indiv' column is missing from the baseline or mixtures. Please check the baseline format.")
+}
+
 if (show_missing_data == TRUE) {
   # Add blank/NA data for columns that are in ref_baseline but missing from unk_match
   missing_cols <- setdiff(names(ref_baseline), names(unk_match))

--- a/conf/azure.config
+++ b/conf/azure.config
@@ -16,7 +16,6 @@ azure {
     batch {
         autoPoolMode = false
         allowPoolCreation = true
-        runOptions = '-e "HOME=${HOME}" -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro'
         deletePoolsOnCompletion = false
     }
     storage {
@@ -32,7 +31,7 @@ azure {
 
 process {
   executor = 'azurebatch'
-  queue = 'tower-pool-3vJW0Lv1ruHEFWsJX8oKDb'
+  queue = 'tower-pool-4O5zxsIPBABAV41Dt3qeWi'
   withName: 'ANALYZE_IDXSTATS' {
     cpus = { 1 * task.attempt }
     memory = { 2.GB * task.attempt }
@@ -44,6 +43,10 @@ process {
   withName: 'BWA_MEM' {
     cpus = { 4 * task.attempt }
     memory = { 1.GB * task.attempt }
+  }
+  withName: 'DIMER_ANALYSIS' {
+    cpus = { 2 * task.attempt }
+    memory = { 2.GB * task.attempt }
   }
   withName: 'FASTQC' {
     cpus = { 3 * task.attempt }

--- a/conf/azure_esm.config
+++ b/conf/azure_esm.config
@@ -28,6 +28,10 @@ process {
     cpus = { 4 * task.attempt }
     memory = { 1.GB * task.attempt }
   }
+  withName: 'DIMER_ANALYSIS' {
+    cpus = { 2 * task.attempt }
+    memory = { 2.GB * task.attempt }
+  }
   withName: 'FASTQC' {
     cpus = { 3 * task.attempt }
     memory = { 4.GB * task.attempt }

--- a/conf/azure_local.config
+++ b/conf/azure_local.config
@@ -58,6 +58,10 @@ process {
     cpus = { 4 * task.attempt }
     memory = { 1.GB * task.attempt }
   }
+  withName: 'DIMER_ANALYSIS' {
+    cpus = { 2 * task.attempt }
+    memory = { 2.GB * task.attempt }
+  }
   withName: 'FASTQC' {
     cpus = { 3 * task.attempt }
     memory = { 4.GB * task.attempt }

--- a/conf/docker.config
+++ b/conf/docker.config
@@ -15,6 +15,10 @@ process {
     cpus = 2
     memory = '1 GB'
   }
+  withName: 'DIMER_ANALYSIS' {
+    cpus = 2
+    memory = '2 GB'
+  }
   withName: 'FASTQC' {
     cpus = 2
     memory = '2 GB'

--- a/conf/ucdavis_hive.config
+++ b/conf/ucdavis_hive.config
@@ -36,6 +36,11 @@ process {
     memory = { 2.GB * task.attempt }
     time = {1.h * task.attempt}
   }
+  withName: 'DIMER_ANALYSIS' {
+    cpus = { 2 * task.attempt }
+    memory = { 1.GB * task.attempt }
+    time = {1.h * task.attempt}
+  }
   withName: 'FASTQC' {
     cpus = { 3 * task.attempt }
     memory = { 2.GB * task.attempt }

--- a/main.nf
+++ b/main.nf
@@ -30,7 +30,7 @@ include { GEN_MHP_SAMPLE_SHEET; PREP_MHP_RDS; GEN_HAPS} from './modules/microhap
 include { RUN_RUBIAS } from './modules/rubias.nf'
 include { STRUC_PARAMS; STRUCTURE } from './modules/structure.nf'
 include { STRUCTURE_ROSA_REPORT } from './modules/rosa.nf'
-include { BCFTOOLS_MPILEUP } from './modules/bcftools.nf'
+include { BCFTOOLS_MPILEUP; BCFTOOLS_MERGE } from './modules/bcftools.nf'
 include { GREB_HAPSTR } from './modules/RoSA_hap_str.nf'
 include { CONCAT_READS } from './modules/concat_reads.nf'
 include { RUN_SEQUOIA } from './modules/sequoia.nf'
@@ -528,11 +528,30 @@ if (params.use_sequoia) { // only validated if Sequoia is used
     combined_bam_files = bam_by_ref
         .join(bai_by_ref)
 
+    // Group BAM and BAI files by reference and chunk them
+    combined_bam_files
+        .flatMap { reference, bams, bais ->
+            // Pair each bam with its corresponding bai
+            def paired = [bams, bais].transpose()
+            // Chunk the paired list
+            def chunks = paired.collate(params.mpileup_chunk_size ?: 500)
+            
+            // Return a list of tuples for each chunk
+            def result = []
+            chunks.eachWithIndex { chunk, index ->
+                def chunk_bams = chunk.collect { it[0] }
+                def chunk_bais = chunk.collect { it[1] }
+                result << tuple(reference, chunk_bams, chunk_bais, index)
+            }
+            return result
+        }
+        .set { mpileup_chunks }
+
     // Build mpileup_input - need to match reference files to BAM groups
     // For 'full' panel, we have two reference types: "full" and "Chinook_FullPanel_VGLL3Six6LFARWRAP"
     if (params.panel?.toLowerCase() == 'full') {
         // Split by reference type
-        combined_bam_files
+        mpileup_chunks
             .branch {
                 fullgenome: it[0] == params.fullgenome_ref_name
                 targetfasta: true
@@ -541,43 +560,59 @@ if (params.use_sequoia) { // only validated if Sequoia is used
 
         // Target FASTA BAMs - match to reference_files
         mpileup_targetfasta = bam_branches.targetfasta
-            .map { reference, bams, bais ->
+            .map { reference, bams, bais, index ->
                 def ref_file = reference_files
                     .collect { file(it) }
                     .find { it.simpleName == reference }
                 if (!ref_file) {
                     error "No exact match found for reference: ${reference}"
                 }
-                tuple(reference, bams, bais, ref_file)
+                tuple(reference, bams, bais, ref_file, index)
             }
 
         // Full genome BAMs - use thinned genome
         mpileup_fullgenome = bam_branches.fullgenome
             .combine(ch_thinned_fasta)
-            .map { reference, bams, bais, ref_fasta ->
-                tuple(reference, bams, bais, ref_fasta)
+            .map { reference, bams, bais, index, ref_fasta ->
+                tuple(reference, bams, bais, ref_fasta, index)
             }
 
         // Merge both
         mpileup_input = mpileup_targetfasta.mix(mpileup_fullgenome)
     } else {
         // Transition panel - only target FASTA references
-        mpileup_input = combined_bam_files
-            .map { reference, bams, bais ->
+        mpileup_input = mpileup_chunks
+            .map { reference, bams, bais, index ->
                 def ref_file = reference_files
                     .collect { file(it) }
                     .find { it.simpleName == reference }
                 if (!ref_file) {
                     error "No exact match found for reference: ${reference}. Use 'full' as the reference panel."
                 }
-                tuple(reference, bams, bais, ref_file)
+                tuple(reference, bams, bais, ref_file, index)
             }
     }
 
     BCFTOOLS_MPILEUP(mpileup_input)
 
-    // Filter VCFs for Greb Hapstr (RoSA) - only need the main reference, not full genome
+    // Group MPILEUP outputs by reference to merge them
+    BCFTOOLS_MPILEUP.out.vcf
+        .groupTuple(by: 0)
+        .set { ch_vcfs_to_merge }
+
     BCFTOOLS_MPILEUP.out.filtered_vcf
+        .groupTuple(by: 0)
+        .set { ch_filtered_vcfs_to_merge }
+
+    // Join them so they can be merged together
+    ch_vcfs_to_merge
+        .join(ch_filtered_vcfs_to_merge)
+        .set { ch_merge_input }
+
+    BCFTOOLS_MERGE(ch_merge_input)
+
+    // Filter VCFs for Greb Hapstr (RoSA) - only need the main reference, not full genome
+    BCFTOOLS_MERGE.out.filtered_vcf
         .filter { reference, vcf -> 
              reference != params.fullgenome_ref_name 
         }
@@ -585,33 +620,43 @@ if (params.use_sequoia) { // only validated if Sequoia is used
 
     GREB_HAPSTR(vcf_for_rosa, rosa_allele_key_ch)
 
-    // Group SAM files for microhaplotype analysis
+    // Group SAM files for microhaplotype analysis and chunk them
     ch_aligned_sam
         .groupTuple(by: 1)
-        .map { sample_id, ref_name, sam_files ->
-            // Search for VCF file in data/VCFs directory of projectDir
-            // VCF file should have the same basename as the reference files.
-            def vcfFile = file("${projectDir}/data/VCFs/${ref_name}.vcf")
-            if (!vcfFile.exists()) {
-                error "VCF file not found for reference: ${ref_name}. Place a file named ${ref_name}.vcf in the data/VCFs of project directory."
+        .flatMap { sample_ids, reference, sams ->
+            // Pair each sample_id with its corresponding sam
+            def paired = [sample_ids, sams].transpose()
+            // Chunk the paired list
+            def chunks = paired.collate(params.mhp_chunk_size ?: 500)
+            
+            // Return a list of tuples for each chunk
+            def result = []
+            chunks.eachWithIndex { chunk, index ->
+                def chunk_sample_ids = chunk.collect { it[0] }
+                def chunk_sams = chunk.collect { it[1] }
+                
+                // Get the VCF file for this reference
+                def vcfFile = file("${projectDir}/data/VCFs/${reference}.vcf")
+                if (!vcfFile.exists()) {
+                    error "VCF file not found for reference: ${reference}."
+                }
+                result << tuple(chunk_sample_ids, reference, vcfFile, chunk_sams, index)
             }
-            tuple(sample_id, ref_name, vcfFile, sam_files)
+            return result
         }
-        .set { packed_for_mhp }
+        .set { packed_for_mhp_chunked }
     
-    // Generate samplesheets
-    GEN_MHP_SAMPLE_SHEET(packed_for_mhp)
+    // Generate samplesheets for each chunk
+    GEN_MHP_SAMPLE_SHEET(packed_for_mhp_chunked)
 
-    // Run Microhaplot to generate RDS files
+    // Run Microhaplot to generate RDS files for each chunk
     PREP_MHP_RDS(GEN_MHP_SAMPLE_SHEET.out.mhp_samplesheet)
 
-    // If we have multiple RDS files (e.g. from target and full genome panels), we need to merge them.
-    // Collect all RDS files across all references
+    // Collect all RDS files across all chunks and references
     PREP_MHP_RDS.out.rds
         .map { reference, rds_files -> rds_files }
         .collect()
         .map { all_rds_files -> 
-             // Use a generic reference name for the combined set, or just use the project name
              tuple("combined", all_rds_files) 
         }
         .set { combined_rds }

--- a/main.nf
+++ b/main.nf
@@ -424,25 +424,13 @@ if (params.use_sequoia) { // only validated if Sequoia is used
             ch_map_bam = MAP_TO_FULL_GENOME_MOUNT.out.bam.transpose()
 
             // Collect indices from Mount version
-            ch_thinned_indices = MAKE_THINNED_GENOME_MOUNT.out.amb
-                .mix(MAKE_THINNED_GENOME_MOUNT.out.ann)
-                .mix(MAKE_THINNED_GENOME_MOUNT.out.bwt)
-                .mix(MAKE_THINNED_GENOME_MOUNT.out.pac)
-                .mix(MAKE_THINNED_GENOME_MOUNT.out.sa)
-                .collect()
-                .map { it.sort() }
+            ch_thinned_indices = MAKE_THINNED_GENOME_MOUNT.out.indices
 
         } else {
             // Standard approach: Download and Index
             DOWNLOAD_AND_INDEX_GENOME()
             
-            ch_genome_indices = DOWNLOAD_AND_INDEX_GENOME.out.amb
-                .mix(DOWNLOAD_AND_INDEX_GENOME.out.ann)
-                .mix(DOWNLOAD_AND_INDEX_GENOME.out.bwt)
-                .mix(DOWNLOAD_AND_INDEX_GENOME.out.pac)
-                .mix(DOWNLOAD_AND_INDEX_GENOME.out.sa)
-                .collect()
-                .map { it.sort() }
+            ch_genome_indices = DOWNLOAD_AND_INDEX_GENOME.out.indices
 
             // Create thinned genome
             MAKE_THINNED_GENOME(
@@ -472,13 +460,7 @@ if (params.use_sequoia) { // only validated if Sequoia is used
             ch_map_bam = MAP_TO_FULL_GENOME.out.bam.transpose()
             
             // Collect indices from Standard version
-            ch_thinned_indices = MAKE_THINNED_GENOME.out.amb
-                .mix(MAKE_THINNED_GENOME.out.ann)
-                .mix(MAKE_THINNED_GENOME.out.bwt)
-                .mix(MAKE_THINNED_GENOME.out.pac)
-                .mix(MAKE_THINNED_GENOME.out.sa)
-                .collect()
-                .map { it.sort() }
+            ch_thinned_indices = MAKE_THINNED_GENOME.out.indices
         }
 
 

--- a/main.nf
+++ b/main.nf
@@ -408,8 +408,12 @@ if (params.use_sequoia) { // only validated if Sequoia is used
             // Map merged reads using mounted files
             // Chunk inputs to reduce genome copy overhead
             ch_processed_reads_chunked = ch_processed_reads
-                .buffer(size: params.fullgenome_chunk_size, remainder: true)
-                .map { chunk -> tuple(chunk.collect{it[0]}, chunk.collect{it[1]}) }
+                .toSortedList({ a, b -> a[0] <=> b[0] })
+                .flatMap { sorted_list -> 
+                    sorted_list.collate(params.fullgenome_chunk_size ?: 30).collect { chunk -> 
+                        tuple(chunk.collect{it[0]}, chunk.collect{it[1]}) 
+                    }
+                }
 
             MAP_TO_FULL_GENOME_MOUNT(
                 ch_processed_reads_chunked,
@@ -426,6 +430,7 @@ if (params.use_sequoia) { // only validated if Sequoia is used
                 .mix(MAKE_THINNED_GENOME_MOUNT.out.pac)
                 .mix(MAKE_THINNED_GENOME_MOUNT.out.sa)
                 .collect()
+                .map { it.sort() }
 
         } else {
             // Standard approach: Download and Index
@@ -437,6 +442,7 @@ if (params.use_sequoia) { // only validated if Sequoia is used
                 .mix(DOWNLOAD_AND_INDEX_GENOME.out.pac)
                 .mix(DOWNLOAD_AND_INDEX_GENOME.out.sa)
                 .collect()
+                .map { it.sort() }
 
             // Create thinned genome
             MAKE_THINNED_GENOME(
@@ -449,8 +455,12 @@ if (params.use_sequoia) { // only validated if Sequoia is used
             // Map merged reads
             // Chunk inputs to reduce genome copy overhead
             ch_processed_reads_chunked = ch_processed_reads
-                .buffer(size: params.fullgenome_chunk_size, remainder: true)
-                .map { chunk -> tuple(chunk.collect{it[0]}, chunk.collect{it[1]}) }
+                .toSortedList({ a, b -> a[0] <=> b[0] })
+                .flatMap { sorted_list -> 
+                    sorted_list.collate(params.fullgenome_chunk_size ?: 30).collect { chunk -> 
+                        tuple(chunk.collect{it[0]}, chunk.collect{it[1]}) 
+                    }
+                }
 
             MAP_TO_FULL_GENOME(
                 ch_processed_reads_chunked,
@@ -468,6 +478,7 @@ if (params.use_sequoia) { // only validated if Sequoia is used
                 .mix(MAKE_THINNED_GENOME.out.pac)
                 .mix(MAKE_THINNED_GENOME.out.sa)
                 .collect()
+                .map { it.sort() }
         }
 
 

--- a/modules/bcftools.nf
+++ b/modules/bcftools.nf
@@ -1,18 +1,16 @@
 process BCFTOOLS_MPILEUP {
-    tag "MPILEUP on ${reference}"
+    tag "MPILEUP on ${reference} chunk ${chunk_index}"
     label 'process_high'
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
     'https://depot.galaxyproject.org/singularity/bcftools:1.21--h8b25389_0':
     'quay.io/biocontainers/bcftools:1.21--h8b25389_0' }"
 
-    publishDir "${params.outdir}/${params.project}/variants", mode: 'copy'
-
     input:
-    tuple val(reference), path(bams), path(bais), path(ref)
+    tuple val(reference), path(bams), path(bais), path(ref), val(chunk_index)
     
     output:
-    tuple val(reference), path("${params.project}_${reference}.vcf"), emit: vcf
-    tuple val(reference), path("${params.project}_${reference}.filtered.vcf"), emit: filtered_vcf
+    tuple val(reference), path("${params.project}_${reference}_chunk${chunk_index}.vcf.gz"), path("${params.project}_${reference}_chunk${chunk_index}.vcf.gz.csi"), emit: vcf
+    tuple val(reference), path("${params.project}_${reference}_chunk${chunk_index}.filtered.vcf.gz"), path("${params.project}_${reference}_chunk${chunk_index}.filtered.vcf.gz.csi"), emit: filtered_vcf
     
     script:
     """
@@ -27,12 +25,40 @@ process BCFTOOLS_MPILEUP {
         -f ${ref} \
         -b bam_list.txt \
         | bcftools call -v -m \
-        | bcftools sort \
-        | bcftools norm -m +any -f ${ref} \
-        > ${params.project}_${reference}.vcf
+        | bcftools sort -O z -o ${params.project}_${reference}_chunk${chunk_index}.vcf.gz
     
-    bcftools view --exclude-types indels ${params.project}_${reference}.vcf \
+    bcftools index ${params.project}_${reference}_chunk${chunk_index}.vcf.gz
+    
+    bcftools view --exclude-types indels ${params.project}_${reference}_chunk${chunk_index}.vcf.gz \
         | bcftools +setGT - -- -t q -i 'FORMAT/DP<5 || QUAL<20' -n . \
-        > ${params.project}_${reference}.filtered.vcf
+        | bcftools sort -O z -o ${params.project}_${reference}_chunk${chunk_index}.filtered.vcf.gz
+
+    bcftools index ${params.project}_${reference}_chunk${chunk_index}.filtered.vcf.gz
+    """
+}
+
+process BCFTOOLS_MERGE {
+    tag "Merge VCFs for ${reference}"
+    label 'process_medium'
+    container 'quay.io/biocontainers/bcftools:1.21--h8b25389_0'
+    publishDir "${params.outdir}/${params.project}/variants", mode: 'copy'
+
+    input:
+    tuple val(reference), path(vcfs), path(vcf_csis), path(filtered_vcfs), path(filtered_vcf_csis)
+
+    output:
+    tuple val(reference), path("${params.project}_${reference}.vcf"), emit: vcf
+    tuple val(reference), path("${params.project}_${reference}.filtered.vcf"), emit: filtered_vcf
+
+    script:
+    """
+    NUM_VCFS=\$(echo "${vcfs}" | wc -w)
+    if [ "\$NUM_VCFS" -eq 1 ]; then
+        bcftools merge --force-single ${vcfs} -o ${params.project}_${reference}.vcf
+        bcftools merge --force-single ${filtered_vcfs} -o ${params.project}_${reference}.filtered.vcf
+    else
+        bcftools merge ${vcfs} -o ${params.project}_${reference}.vcf
+        bcftools merge ${filtered_vcfs} -o ${params.project}_${reference}.filtered.vcf
+    fi
     """
 }

--- a/modules/fullgenome/download_genome.nf
+++ b/modules/fullgenome/download_genome.nf
@@ -10,11 +10,7 @@ process DOWNLOAD_AND_INDEX_GENOME {
     output:
     path "Otsh_v1.0.fna", emit: genome
     path "Otsh_v1.0.fna.fai", emit: fai
-    path "Otsh_v1.0.fna.amb", emit: amb
-    path "Otsh_v1.0.fna.ann", emit: ann
-    path "Otsh_v1.0.fna.bwt", emit: bwt
-    path "Otsh_v1.0.fna.pac", emit: pac
-    path "Otsh_v1.0.fna.sa", emit: sa
+    path "Otsh_v1.0.fna.{amb,ann,bwt,pac,sa}", emit: indices
 
     script:
     """

--- a/modules/fullgenome/make_thinned_genome.nf
+++ b/modules/fullgenome/make_thinned_genome.nf
@@ -16,11 +16,7 @@ process MAKE_THINNED_GENOME {
     output:
     path "thinned.fna", emit: fasta
     path "thinned.fna.fai", emit: fai
-    path "thinned.fna.amb", emit: amb
-    path "thinned.fna.ann", emit: ann
-    path "thinned.fna.bwt", emit: bwt
-    path "thinned.fna.pac", emit: pac
-    path "thinned.fna.sa", emit: sa
+    path "thinned.fna.{amb,ann,bwt,pac,sa}", emit: indices
 
     script:
     """
@@ -47,11 +43,7 @@ process MAKE_THINNED_GENOME_MOUNT {
     output:
     path "thinned.fna", emit: fasta
     path "thinned.fna.fai", emit: fai
-    path "thinned.fna.amb", emit: amb
-    path "thinned.fna.ann", emit: ann
-    path "thinned.fna.bwt", emit: bwt
-    path "thinned.fna.pac", emit: pac
-    path "thinned.fna.sa", emit: sa
+    path "thinned.fna.{amb,ann,bwt,pac,sa}", emit: indices
 
     script:
     """

--- a/modules/microhaplot.nf
+++ b/modules/microhaplot.nf
@@ -1,15 +1,15 @@
 process GEN_MHP_SAMPLE_SHEET {
-    tag "Generate MHP samplesheet: $reference"
+    tag "Generate MHP samplesheet: $reference chunk $chunk_index"
     label 'process_xsmall'
     container 'docker.io/nfcore/base:2.1'
 
-    publishDir "${params.outdir}/${params.project}/mhp", mode: 'copy', pattern: '*_mhp_samplesheet.tsv', saveAs: { filename -> "${reference}/$filename" }
+    publishDir "${params.outdir}/${params.project}/mhp", mode: 'copy', pattern: '*_mhp_samplesheet.tsv', saveAs: { filename -> "${reference}/chunk${chunk_index}/$filename" }
 
     input:
-    tuple val(sample_id), val(reference), path(vcf), path(aligned_sam_files)
+    tuple val(sample_ids), val(reference), path(vcf), path(aligned_sam_files), val(chunk_index)
 
     output:
-    tuple val(reference), path("${params.project}_${reference}_mhp_samplesheet.tsv"), path(vcf), path(aligned_sam_files), emit: mhp_samplesheet
+    tuple val(reference), val(chunk_index), path("${params.project}_${reference}_chunk${chunk_index}_mhp_samplesheet.tsv"), path(vcf), path(aligned_sam_files), emit: mhp_samplesheet
 
     script:
     """
@@ -17,21 +17,21 @@ process GEN_MHP_SAMPLE_SHEET {
     for sam_file in ${aligned_sam_files}; do
         if [[ "\$sam_file" == *.sam ]]; then
             base_name=\$(basename "\$sam_file" ${reference}_aln.sam)
-            echo -e "\$sam_file\t\$base_name\tNA" >> "${params.project}_${reference}_mhp_samplesheet.tsv"
+            echo -e "\$sam_file\t\$base_name\tNA" >> "${params.project}_${reference}_chunk${chunk_index}_mhp_samplesheet.tsv"
         fi
     done
-    sort -u -o "${params.project}_${reference}_mhp_samplesheet.tsv" "${params.project}_${reference}_mhp_samplesheet.tsv"
+    sort -u -o "${params.project}_${reference}_chunk${chunk_index}_mhp_samplesheet.tsv" "${params.project}_${reference}_chunk${chunk_index}_mhp_samplesheet.tsv"
     """
 }
 
 process PREP_MHP_RDS {
-    tag "Prepare Microhaplotype RDS files: $reference"
+    tag "Prepare Microhaplotype RDS files: $reference chunk $chunk_index"
     label 'process_high'
     container 'docker.io/bnguyen29/r-rubias:1.0.4'
-    publishDir "${params.outdir}/${params.project}/mhp", mode: 'copy', saveAs: { filename -> "${reference}/$filename" }
+    publishDir "${params.outdir}/${params.project}/mhp", mode: 'copy', saveAs: { filename -> "${reference}/chunk${chunk_index}/$filename" }
 
     input:
-    tuple val(reference), path(samplesheet), path(vcf_file), path(sam_files)
+    tuple val(reference), val(chunk_index), path(samplesheet), path(vcf_file), path(sam_files)
 
     output:
     tuple val(reference), path("*.rds"), emit: rds
@@ -39,7 +39,7 @@ process PREP_MHP_RDS {
     script:
     """
     # Needs to take in reference info and output reference info in the RDS file
-    prep_mhp_rds.R ${samplesheet} ${vcf_file} ${params.project} ${task.cpus} ${reference}
+    prep_mhp_rds.R ${samplesheet} ${vcf_file} ${params.project} ${task.cpus} ${reference}_chunk${chunk_index}
     """
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -58,6 +58,8 @@ params {
     CKMR_extra_genos_allele_freqs = "$projectDir/examples/PBT/JPE2022-2024_geno_wide.csv"
     fullgenome_region_file = "$projectDir/data/regions/Chinook_FullPanel_VGLL3Six6LFARWRAP-Otsh_v1.0.txt"
     fullgenome_chunk_size = 30
+    mpileup_chunk_size = 500
+    mhp_chunk_size = 500
     // Other params remain the same
 }
 


### PR DESCRIPTION
These changes include improvements to the Nextflow pipeline that streamline module outputs from genome download and indexing to prevent it from invalidating the cache upon resuming. Chunking (with sorting to make the flow more deterministic) for bcftools and microhaplot was also implemented.

tbl_df() is used by a dependency and no longer works. workaround coded in.