### PR TITLE
Fix cache invalidation downstream of bcftools and add azure_large config

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ To create a custom profile for your environment:
 
 ### Processing Options
 
+- **`run_fastqc`** (boolean, default: `false`)
+  Run FastQC quality control analysis on raw FASTQ files. Set to `true` to enable FastQC.
+
+- **`run_dimer_check`** (boolean, default: `true`)
+  Run primer dimer analysis (`DIMER_ANALYSIS` module). Set to `false` to disable.
+
 - **`concat_all_reads`** (boolean, default: `false`)
   Concatenate all available reads per sample (merged, unmerged, and unpaired) for BWA mapping. If false, uses only merged and single-end reads.
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ The pipeline supports multiple execution profiles configured in the `conf/` dire
   - Auto-scaling compute pools
   - Azure Blob Storage for work and results
 
+- **`azure_large`** - Azure Batch profile optimized for large sample numbers (>1,000 samples)
+  - Increased memory allocations for `GEN_HAPS`, `PREP_MHP_RDS`, `RUN_RUBIAS`, `MULTIQC`, and `ANALYZE_IDXSTATS` to prevent OOM errors
+
 - **`azure_local`** - Azure Batch with local adapter files
   - Similar to `azure` but uses local reference files instead of cloud storage
 

--- a/conf/azure.config
+++ b/conf/azure.config
@@ -17,6 +17,7 @@ azure {
         autoPoolMode = false
         allowPoolCreation = true
         deletePoolsOnCompletion = false
+        terminateJobsOnCompletion = true
     }
     storage {
         fileShares {

--- a/conf/azure.config
+++ b/conf/azure.config
@@ -47,10 +47,12 @@ process {
   withName: 'DIMER_ANALYSIS' {
     cpus = { 2 * task.attempt }
     memory = { 2.GB * task.attempt }
+    errorStrategy = 'retry'
   }
   withName: 'FASTQC' {
     cpus = { 3 * task.attempt }
     memory = { 4.GB * task.attempt }
+    errorStrategy = 'ignore'
   }
   withName: 'FLASH2' {
     cpus = { 2 * task.attempt }
@@ -71,6 +73,7 @@ process {
   withName: 'MULTIQC' {
     cpus = { 2 * task.attempt }
     memory = { 8.GB * task.attempt }
+    errorStrategy = 'ignore'
   }
   withName: 'PREP_MHP_RDS' {
     cpus = { 2 * task.attempt }
@@ -79,6 +82,7 @@ process {
   withName: 'RUN_RUBIAS' {
     cpus = { 2 * task.attempt }
     memory = { 2.GB * task.attempt }
+    errorStrategy = 'finish'
   }
   withName: 'SAMTOOLS' {
     cpus = { 1 * task.attempt }
@@ -107,10 +111,12 @@ process {
   withName: 'CKMR_PO' {
     cpus = { 4 * task.attempt }
     memory = { 10.GB * task.attempt }
+    errorStrategy = 'finish'
   }
   withName: 'RUN_SEQUOIA' {
     cpus = { 4 * task.attempt }
     memory = { 10.GB * task.attempt }
+    errorStrategy = 'finish'
   }
   withName: 'MAP_TO_FULL_GENOME|MAP_TO_FULL_GENOME_MOUNT' {
     cpus = { 4 }  

--- a/conf/azure_large.config
+++ b/conf/azure_large.config
@@ -1,0 +1,148 @@
+docker.runOptions = '-v /mnt/batch/tasks/fsmounts/seqres:/mnt/batch/tasks/fsmounts/seqres'
+docker.enabled = true
+workDir = 'az://nextflow/work'
+params {
+    outdir = 'az://nextflow/results/chinookGT_full'
+    adapter_file = 'az://nextflow/reference/adapters/GTseq-PE.fa'
+    genome_cache = 'az://nextflow/reference/genomes'
+    fullgenome_chunk_size = 30
+}
+
+
+azure {
+    retryPolicy {
+        delay = '30000ms'
+    }
+    batch {
+        autoPoolMode = false
+        allowPoolCreation = true
+        deletePoolsOnCompletion = false
+        terminateJobsOnCompletion = true
+    }
+    storage {
+        fileShares {
+            seqres {
+                mountPath = "/mnt/batch/tasks/fsmounts/seqres"
+                //mountPath = "/mnt/seqres"
+                mountOptions = "vers=3.0,dir_mode=0755,file_mode=0755,serverino,nosharesock"
+            }
+        }
+    }
+}
+
+process {
+  executor = 'azurebatch'
+  queue = 'tower-pool-4O5zxsIPBABAV41Dt3qeWi'
+  withName: 'ANALYZE_IDXSTATS' {
+    cpus = { 2 * task.attempt }
+    memory = { 6.GB * task.attempt }
+  }
+  withName: 'BCFTOOLS_MPILEUP' {
+    cpus = { 4 * task.attempt }
+    memory = { 12.GB * task.attempt }
+  }
+  withName: 'BWA_MEM' {
+    cpus = { 4 * task.attempt }
+    memory = { 1.GB * task.attempt }
+  }
+  withName: 'DIMER_ANALYSIS' {
+    cpus = { 2 * task.attempt }
+    memory = { 2.GB * task.attempt }
+    errorStrategy = 'retry'
+  }
+  withName: 'FASTQC' {
+    cpus = { 3 * task.attempt }
+    memory = { 4.GB * task.attempt }
+    errorStrategy = 'ignore'
+  }
+  withName: 'FLASH2' {
+    cpus = { 2 * task.attempt }
+    memory = { 2.GB * task.attempt }
+  }
+  withName: 'GEN_HAPS' {
+    cpus = { 4 * task.attempt }
+    memory = { 16.GB * task.attempt }
+  }
+  withName: 'GEN_MHP_SAMPLE_SHEET' {
+    cpus = { 2 * task.attempt }
+    memory = { 4.GB * task.attempt }
+  }
+  withName: 'GREB_HAPSTR' {
+    cpus = { 2 * task.attempt }
+    memory = { 4.GB * task.attempt }
+  }
+  withName: 'MULTIQC' {
+    cpus = { 4 * task.attempt }
+    memory = { 16.GB * task.attempt }
+    errorStrategy = 'ignore'
+  }
+  withName: 'PREP_MHP_RDS' {
+    cpus = { 2 * task.attempt }
+    memory = { 6.GB * task.attempt }
+  }
+  withName: 'RUN_RUBIAS' {
+    cpus = { 4 * task.attempt }
+    memory = { 16.GB * task.attempt }
+    errorStrategy = 'finish'
+  }
+  withName: 'SAMTOOLS' {
+    cpus = { 1 * task.attempt }
+    memory = { 1.GB * task.attempt }
+  }
+  withName: 'STRUCTURE' {
+    cpus = { 2 * task.attempt }
+    memory = { 1.GB * task.attempt }
+  }
+  withName: 'STRUCTURE_ROSA_REPORT' {
+    cpus = { 2 * task.attempt }
+    memory = { 1.GB * task.attempt }
+  }
+  withName: 'STRUC_PARAMS' {
+    cpus = { 1 * task.attempt }
+    memory = { 1.GB * task.attempt }
+  }
+  withName: 'TRIMMOMATIC' {
+    cpus = { 4 * task.attempt }
+    memory = { 2.GB * task.attempt }
+  }
+  withName: 'CONCAT_READS' {
+    cpus = { 1 * task.attempt }
+    memory = { 1.GB * task.attempt }
+  }
+  withName: 'CKMR_PO' {
+    cpus = { 4 * task.attempt }
+    memory = { 10.GB * task.attempt }
+    errorStrategy = 'finish'
+  }
+  withName: 'RUN_SEQUOIA' {
+    cpus = { 4 * task.attempt }
+    memory = { 10.GB * task.attempt }
+    errorStrategy = 'finish'
+  }
+  withName: 'MAP_TO_FULL_GENOME|MAP_TO_FULL_GENOME_MOUNT' {
+    cpus = { 4 }  
+    memory = { 12.GB + (2.GB * (task.attempt - 1)) }
+  }
+  withName: 'BAM_TO_FASTQ' {
+    cpus = { 1 * task.attempt }
+    memory = { 2.GB * task.attempt }
+  }
+  withName: 'DOWNLOAD_AND_INDEX_GENOME' {
+    cpus = { 4 * task.attempt }
+    memory = { 12.GB * task.attempt }
+  }
+  withName: 'EXTRACT_READS_FROM_REGIONS' {
+    cpus = { 1 * task.attempt }
+    memory = { 2.GB * task.attempt }
+  }
+  withName: 'MAKE_THINNED_GENOME|MAKE_THINNED_GENOME_MOUNT' {
+    cpus = { 2 * task.attempt }
+    memory = { 6.GB * task.attempt }
+  }
+  withName: 'REMAP_TO_THINNED_GENOME' {
+    cpus = { 1 * task.attempt }
+    memory = { 2.GB * task.attempt }
+  }
+  errorStrategy = 'retry'
+  maxRetries = 2
+}

--- a/conf/azure_local.config
+++ b/conf/azure_local.config
@@ -126,9 +126,9 @@ process {
     cpus = { 4 * task.attempt }
     memory = { 10.GB * task.attempt }
   }
-  withName: 'MAP_TO_FULL_GENOME' {
+  withName: 'MAP_TO_FULL_GENOME|MAP_TO_FULL_GENOME_MOUNT' {
     cpus = { 2 + (1 * task.attempt) }
-    memory = { 4.GB + (1.GB * (task.attempt - 1)) }
+    memory = { 12.GB + (2.GB * (task.attempt - 1)) }
     maxForks = 30
   }
   withName: 'BAM_TO_FASTQ' {

--- a/main.nf
+++ b/main.nf
@@ -510,36 +510,22 @@ if (params.use_sequoia) { // only validated if Sequoia is used
     // Run the analysis
     ANALYZE_IDXSTATS(idxstats_main)
 
-    // Group BAM and BAI files by reference
-    bam_by_ref = SAMTOOLS.out.sorted_bam
-        .map { sample_id, reference, bam -> 
-            tuple(reference, bam) 
+    // Join sorted BAM and BAI by [sample_id, reference] to guarantee correct pairing
+    SAMTOOLS.out.sorted_bam
+        .join(SAMTOOLS.out.sorted_bam_index, by: [0, 1])
+        .map { sample_id, reference, bam, bai -> 
+            tuple(reference, sample_id, bam, bai) 
         }
         .groupTuple(by: 0)
-
-    bai_by_ref = SAMTOOLS.out.sorted_bam_index
-        .map { sample_id, reference, bai -> 
-            tuple(reference, bai) 
-        }
-        .groupTuple(by: 0)
-
-    // Join BAM and BAI groups by reference
-    combined_bam_files = bam_by_ref
-        .join(bai_by_ref)
-
-    // Group BAM and BAI files by reference and chunk them
-    combined_bam_files
-        .flatMap { reference, bams, bais ->
-            // Pair each bam with its corresponding bai
-            def paired = [bams, bais].transpose()
-            // Chunk the paired list
+        .flatMap { reference, sample_ids, bams, bais ->
+            // Zip sample attributes and sort deterministically by sample_id to prevent cache invalidation on resume
+            def paired = [sample_ids, bams, bais].transpose().sort { a, b -> a[0] <=> b[0] }
             def chunks = paired.collate(params.mpileup_chunk_size ?: 500)
             
-            // Return a list of tuples for each chunk
             def result = []
             chunks.eachWithIndex { chunk, index ->
-                def chunk_bams = chunk.collect { it[0] }
-                def chunk_bais = chunk.collect { it[1] }
+                def chunk_bams = chunk.collect { it[1] }
+                def chunk_bais = chunk.collect { it[2] }
                 result << tuple(reference, chunk_bams, chunk_bais, index)
             }
             return result
@@ -594,13 +580,21 @@ if (params.use_sequoia) { // only validated if Sequoia is used
 
     BCFTOOLS_MPILEUP(mpileup_input)
 
-    // Group MPILEUP outputs by reference to merge them
+    // Group MPILEUP outputs by reference and sort deterministically by filename before merging
     BCFTOOLS_MPILEUP.out.vcf
         .groupTuple(by: 0)
+        .map { reference, vcfs, csis ->
+            def sorted = [vcfs, csis].transpose().sort { a, b -> a[0].name <=> b[0].name }
+            tuple(reference, sorted.collect { it[0] }, sorted.collect { it[1] })
+        }
         .set { ch_vcfs_to_merge }
 
     BCFTOOLS_MPILEUP.out.filtered_vcf
         .groupTuple(by: 0)
+        .map { reference, vcfs, csis ->
+            def sorted = [vcfs, csis].transpose().sort { a, b -> a[0].name <=> b[0].name }
+            tuple(reference, sorted.collect { it[0] }, sorted.collect { it[1] })
+        }
         .set { ch_filtered_vcfs_to_merge }
 
     // Join them so they can be merged together
@@ -623,8 +617,8 @@ if (params.use_sequoia) { // only validated if Sequoia is used
     ch_aligned_sam
         .groupTuple(by: 1)
         .flatMap { sample_ids, reference, sams ->
-            // Pair each sample_id with its corresponding sam
-            def paired = [sample_ids, sams].transpose()
+            // Pair each sample_id with its corresponding sam and sort deterministically
+            def paired = [sample_ids, sams].transpose().sort { a, b -> a[0] <=> b[0] }
             // Chunk the paired list
             def chunks = paired.collate(params.mhp_chunk_size ?: 500)
             
@@ -651,12 +645,12 @@ if (params.use_sequoia) { // only validated if Sequoia is used
     // Run Microhaplot to generate RDS files for each chunk
     PREP_MHP_RDS(GEN_MHP_SAMPLE_SHEET.out.mhp_samplesheet)
 
-    // Collect all RDS files across all chunks and references
+    // Collect all RDS files across all chunks and references, sorting deterministically
     PREP_MHP_RDS.out.rds
         .map { reference, rds_files -> rds_files }
         .collect()
         .map { all_rds_files -> 
-             tuple("combined", all_rds_files) 
+             tuple("combined", all_rds_files.flatten().sort { a, b -> a.name <=> b.name }) 
         }
         .set { combined_rds }
 

--- a/main.nf
+++ b/main.nf
@@ -175,6 +175,8 @@ if (params.use_sequoia) { // only validated if Sequoia is used
     Female Sex ID Threshold : ${params.female_sexid_threshold}
     Sex ID Min Reads        : ${params.sexid_min_reads}
     Other parameters:
+    Run FastQC              : ${params.run_fastqc}
+    Run Dimer Check         : ${params.run_dimer_check}
     Concatenate All Reads   : ${params.concat_all_reads}
     Sequoia Parameters:
     Use Sequoia             : ${params.use_sequoia}
@@ -297,11 +299,14 @@ if (params.use_sequoia) { // only validated if Sequoia is used
             .set { ch_input_reads }
     }
         
-    ch_input_fastq = Channel
-        .fromPath(params.input, checkIfExists: true)
-        .collect()
+    if (params.run_fastqc) {
+        ch_input_fastq = Channel
+            .fromPath(params.input, checkIfExists: true)
+            .collect()
+        FASTQC(ch_input_fastq) // FASTQC all input files
+    }
 
-        // Branch workflow based on read type
+    // Branch workflow based on read type
     ch_input_reads
         .branch {
             paired: it[1] == 'paired'
@@ -314,17 +319,18 @@ if (params.use_sequoia) { // only validated if Sequoia is used
         .combine(adapters_ch)
         .set { ch_paired_adapters }
 
+    if (params.run_dimer_check) {
+        DIMER_ANALYSIS(ch_reads_branched.paired, params.min_overlap, params.min_outie_overlap, params.max_overlap)
 
-    
-    FASTQC(ch_input_fastq) // FASTQC all input files
-    DIMER_ANALYSIS(ch_reads_branched.paired, params.min_overlap, params.min_outie_overlap, params.max_overlap)
-
-    merged_counts = DIMER_ANALYSIS.out.counts
-        .collectFile(
-            name: 'dimer_counts_mqc.tsv',
-            keepHeader: true,
-            storeDir: "${params.outdir}/${params.project}/dimers/summary"
-        )
+        merged_counts = DIMER_ANALYSIS.out.counts
+            .collectFile(
+                name: 'dimer_counts_mqc.tsv',
+                keepHeader: true,
+                storeDir: "${params.outdir}/${params.project}/dimers/summary"
+            )
+    } else {
+        merged_counts = Channel.empty()
+    }
 
     TRIMMOMATIC(ch_paired_adapters, params.trim_params)
     FLASH2(TRIMMOMATIC.out.trimmed_paired, params.min_overlap, params.min_outie_overlap, params.max_overlap)
@@ -659,12 +665,16 @@ if (params.use_sequoia) { // only validated if Sequoia is used
 
     // Collect all QC files
     ch_multiqc_files = Channel.empty()
-    ch_multiqc_files = ch_multiqc_files.mix(FASTQC.out.fastqc_results)
+    if (params.run_fastqc) {
+        ch_multiqc_files = ch_multiqc_files.mix(FASTQC.out.fastqc_results)
+    }
     ch_multiqc_files = ch_multiqc_files.mix(TRIMMOMATIC.out.log)
     ch_multiqc_files = ch_multiqc_files.mix(FLASH2.out.log)
     //ch_multiqc_files = ch_multiqc_files.mix(BWA_MEM.out.log)
     ch_multiqc_files = ch_multiqc_files.mix(SAMTOOLS.out.idxstats.collect{it[2]})
-    ch_multiqc_files = ch_multiqc_files.mix(merged_counts)
+    if (params.run_dimer_check) {
+        ch_multiqc_files = ch_multiqc_files.mix(merged_counts)
+    }
     //ch_multiqc_files.view { println "Debug: MultiQC input file: $it" }
     MULTIQC(ch_multiqc_files.collect())
     

--- a/nextflow.config
+++ b/nextflow.config
@@ -35,6 +35,8 @@ params {
     gsi_missing_threshold = 0.6
     pofz_threshold = 0.8
     concat_all_reads = false
+    run_fastqc = false
+    run_dimer_check = true
     use_sequoia = false
     sequoia_mode = 'par'
     sequoia_missing_threshold = 0.5

--- a/nextflow.config
+++ b/nextflow.config
@@ -76,6 +76,10 @@ profiles {
         process.executor = 'azurebatch'
         includeConfig 'conf/azure.config'
     }
+    azure_large {
+        process.executor = 'azurebatch'
+        includeConfig 'conf/azure_large.config'
+    }
     azure_local {
         process.executor = 'azurebatch'
         includeConfig 'conf/azure_local.config'

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -66,6 +66,16 @@
             "type": "object",
             "description": "Options for read processing and data handling.",
             "properties": {
+                "run_fastqc": {
+                    "type": "boolean",
+                    "description": "Run FastQC quality control analysis on raw FASTQ files.",
+                    "default": false
+                },
+                "run_dimer_check": {
+                    "type": "boolean",
+                    "description": "Run primer dimer analysis (DIMER_ANALYSIS module).",
+                    "default": true
+                },
                 "concat_all_reads": {
                     "type": "boolean",
                     "description": "Concatenate all available reads per sample (merged, unmerged, and unpaired) for BWA mapping. If false, uses only merged and single-end reads (original behavior).",

--- a/qc.nf
+++ b/qc.nf
@@ -23,7 +23,7 @@ include { MULTIQC } from './modules/multiqc'
 workflow {
     ch_multiqc_files = Channel.empty()
 
-    if (params.run_fastqc != false) {
+    if (params.run_fastqc) {
         ch_input_fastq = Channel // all fastq files for FastQC
             .fromPath(params.input, checkIfExists: true)
             .collect()

--- a/qc.nf
+++ b/qc.nf
@@ -20,17 +20,17 @@ nextflow.enable.dsl = 2
 include { FASTQC } from './modules/fastqc'
 include { MULTIQC } from './modules/multiqc'
 
-ch_input_fastq = Channel // all fastq files for FastQC
-    .fromPath(params.input, checkIfExists: true)
-    .collect()
-
 workflow {
-    FASTQC(ch_input_fastq)
-    
-    // Collect all QC files
     ch_multiqc_files = Channel.empty()
-    ch_multiqc_files = ch_multiqc_files.mix(FASTQC.out.fastqc_results)
-    MULTIQC(ch_multiqc_files.collect())
 
+    if (params.run_fastqc != false) {
+        ch_input_fastq = Channel // all fastq files for FastQC
+            .fromPath(params.input, checkIfExists: true)
+            .collect()
+        FASTQC(ch_input_fastq)
+        ch_multiqc_files = ch_multiqc_files.mix(FASTQC.out.fastqc_results)
+    }
+
+    MULTIQC(ch_multiqc_files.collect())
 }
 

--- a/test_settings.yml
+++ b/test_settings.yml
@@ -18,7 +18,9 @@ n_loci: 204
 rubias_show_missing_data: "TRUE"
 
 concat_all_reads: false
-use_CKMR: TRUE
+run_fastqc: false
+run_dimer_check: true
+use_CKMR: FALSE
 CKMR_logl_threshold: 6.9
 CKMR_min_loci: 90
 CKMR_parent_geno_input: "examples/PBT/FRH2024_reference_genotypes.csv"


### PR DESCRIPTION
The BCFTOOLS_MPILEUP module and a few other downstream processes were receiving non-deterministic inputs which resulted in cache invalidation. This should be fixed now.

Parameters `run_fastqc` and `run_dimer_check` were added.

Additionally, a new config/profile called `azure_large` was added for better handling very large runs. It has more flexible error strategies in case certain non-critical processes fail. We're still running into an issue where the Nextflow head node seems to be running out of space or memory when resuming runs with a lot of cached tasks, but this may be resolvable by providing the head node and Nextflow more memory. I have not tested this yet.