### PR TITLE
no longer removing trailing _R123 in sample names

### DIFF
--- a/bin/gen_haps.R
+++ b/bin/gen_haps.R
@@ -21,7 +21,6 @@ clean_sample_name <- function(x) {
   x %>%
     str_remove("_$") %>% # Remove trailing underscore
     str_remove("_S\\d+_?$") %>% # Remove _S123_ suffix
-    str_remove("_R\\d+_?$") %>% # Remove _R123_ suffix
     str_remove("_L\\d+_?$") # Remove _L123_ suffix
 }
 

--- a/bin/rubias.R
+++ b/bin/rubias.R
@@ -9,7 +9,6 @@ clean_sample_name <- function(x) {
   x %>%
     str_remove("_$") %>% # Remove trailing underscore
     str_remove("_S\\d+_?$") %>% # Remove _S123_ suffix
-    str_remove("_R\\d+_?$") %>% # Remove _R123_ suffix
     str_remove("_L\\d+_?$") # Remove _L123_ suffix
 }
 


### PR DESCRIPTION
Deleting code that removes trailing `_R123_` from sample names